### PR TITLE
Fix codecommit client creation

### DIFF
--- a/codecommit/codecommit.go
+++ b/codecommit/codecommit.go
@@ -6,7 +6,7 @@ import (
 
 // NewDefault returns a new codecommit client.
 func NewDefault() *scm.Client {
-	client := &wrapper{}
+	client := &wrapper{new(scm.Client)}
 	client.Webhooks = &webhookService{}
 	return client.Client
 }


### PR DESCRIPTION
Codecommit default client creation is failing with segfault error. This patch will fix that issue.